### PR TITLE
🔧 Chore: Azure 배포 인프라 및 CI/CD 파이프라인 구성 (#11)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,6 +4,10 @@ on:
   push:
     branches: [main]
 
+concurrency:
+  group: deploy-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   id-token: write
   contents: read
@@ -36,7 +40,7 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
-            type=sha,prefix=
+            type=sha,prefix=,format=long
             type=raw,value=latest
 
       - name: Build and push Docker image

--- a/infra/setup.sh
+++ b/infra/setup.sh
@@ -105,6 +105,22 @@ if az containerapp show --resource-group "$RESOURCE_GROUP" --name "$CONTAINER_AP
       "gemini-api-key=$GEMINI_API_KEY" \
       "youtube-api-key=$YOUTUBE_API_KEY" \
     --output none
+
+  az containerapp update \
+    --resource-group "$RESOURCE_GROUP" \
+    --name "$CONTAINER_APP_NAME" \
+    --set-env-vars \
+      "DATABASE_URL=secretref:database-url" \
+      "JWT_SECRET=secretref:jwt-secret" \
+      "GEMINI_API_KEY=secretref:gemini-api-key" \
+      "YOUTUBE_API_KEY=secretref:youtube-api-key" \
+      "APPLE_CLIENT_ID=com.ddukddak.recipe" \
+      "GOOGLE_CLIENT_ID=$GOOGLE_CLIENT_ID" \
+      "KAKAO_CLIENT_ID=$KAKAO_CLIENT_ID" \
+      "DEBUG=false" \
+      "ACCESS_TOKEN_EXPIRE_MINUTES=60" \
+      "REFRESH_TOKEN_EXPIRE_DAYS=30" \
+    --output none
 else
   log "Creating Container App: $CONTAINER_APP_NAME"
   az containerapp create \
@@ -169,7 +185,7 @@ else
       "name": "github-actions-deploy",
       "issuer": "https://token.actions.githubusercontent.com",
       "subject": "repo:'"$GITHUB_ORG"'/'"$GITHUB_REPO"':ref:refs/heads/'"$GITHUB_BRANCH"'",
-      "description": "GitHub Actions OIDC for dev branch deployment",
+      "description": "GitHub Actions OIDC for '"$GITHUB_BRANCH"' branch deployment",
       "audiences": ["api://AzureADTokenExchange"]
     }' \
     --output none


### PR DESCRIPTION
## 개요
Azure Container Apps 배포를 위한 인프라 셋업 스크립트와 GitHub Actions CI/CD 파이프라인 추가

## 변경 사항
- `infra/setup.sh`: Azure 리소스 원클릭 프로비저닝 스크립트
  - Resource Group, PostgreSQL Flexible Server (B1ms), Container Apps Environment
  - Container App (0.25 vCPU / 0.5Gi, min=0 / max=1)
  - Service Principal + OIDC Federated Credential (GitHub Actions용)
  - 민감값은 Container Apps Secrets로 관리 (`secretref:`)
- `.github/workflows/deploy.yml`: main 브랜치 push 시 자동 배포
  - GHCR에 Docker 이미지 빌드 & 푸시
  - Azure OIDC 로그인 (비밀번호 없이 인증)
  - Container Apps에 이미지 업데이트

## 관련 이슈
- closes #11


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 메인 브랜치 푸시 시 Docker 이미지 빌드·푸시 및 Azure에 배포하는 자동 워크플로우 추가.
  * Azure 리소스 그룹, PostgreSQL 서버, 컨테이너 앱 환경 및 GitHub 인증 설정을 자동화하는 인프라 설정 스크립트 추가.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->