### PR TITLE
✨ Feat: YouTube Shorts URL 지원 (#16)

### DIFF
--- a/app/services/youtube.py
+++ b/app/services/youtube.py
@@ -9,7 +9,7 @@ from app.core.exceptions import AppException, VideoNotFoundException
 settings = get_settings()
 
 _VIDEO_ID_PATTERN = re.compile(
-    r"(?:youtube\.com/watch\?v=|youtu\.be/|youtube\.com/embed/)([a-zA-Z0-9_-]{11})"
+    r"(?:youtube\.com/watch\?v=|youtu\.be/|youtube\.com/embed/|youtube\.com/shorts/)([a-zA-Z0-9_-]{11})"
 )
 
 


### PR DESCRIPTION
## 개요
YouTube Shorts URL을 레시피 분석에 지원

## 변경 사항
- URL 파싱 정규식에 `youtube.com/shorts/` 패턴 추가

## 관련 이슈
- closes #16


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능

* YouTube 쇼츠(Shorts) URL 지원이 추가되었습니다. 이제 쇼츠 링크에서 비디오 ID를 추출할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->