### PR TITLE
⚡ Perf: Cold start 방지를 위한 Keep-alive 설정 (#24)

### DIFF
--- a/.github/workflows/keep-alive.yml
+++ b/.github/workflows/keep-alive.yml
@@ -2,12 +2,13 @@ name: Keep Alive
 
 on:
   schedule:
-    - cron: '*/5 * * * *'
+    - cron: '*/5 9-14 * * *'
   workflow_dispatch:
 
 jobs:
   ping:
     runs-on: ubuntu-latest
+    timeout-minutes: 2
     steps:
       - name: Ping health endpoint
-        run: curl -sf ${{ secrets.SERVER_URL }}/v1/health || true
+        run: curl -sf --connect-timeout 10 --max-time 30 ${{ secrets.SERVER_URL }}/v1/health || true

--- a/.github/workflows/keep-alive.yml
+++ b/.github/workflows/keep-alive.yml
@@ -1,0 +1,13 @@
+name: Keep Alive
+
+on:
+  schedule:
+    - cron: '*/5 * * * *'
+  workflow_dispatch:
+
+jobs:
+  ping:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Ping health endpoint
+        run: curl -sf ${{ secrets.SERVER_URL }}/v1/health || true


### PR DESCRIPTION
## 개요
GitHub Actions cron으로 5분마다 서버에 ping을 보내 cold start를 방지한다.

## 변경 사항
- Keep-alive 워크플로우 추가 (5분 간격 cron + 수동 실행 지원)
- `SERVER_URL` 시크릿을 통한 health check ping

## 관련 이슈
- closes #24


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * 서비스 활성 유지를 위한 신규 "Keep Alive" 워크플로우가 추가되었습니다. 이 워크플로우는 주기적 및 수동 트리거로 서버의 상태를 확인해 서비스를 지속적으로 깨어 있게 하며, 제한된 실행 시간으로 빠르게 동작하도록 구성되어 중단 없이 가용성을 개선합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->