### PR TITLE
✨ Feat: Refresh token 인메모리 저장 및 무효화 (#26)

### DIFF
--- a/app/api/auth.py
+++ b/app/api/auth.py
@@ -15,9 +15,9 @@ async def login(body: LoginRequest, session: DBSession) -> ApiResponse[LoginResp
     return ok(result)
 
 @router.post("/logout")
-async def logout(body: RefreshRequest, _user_id: CurrentUserId, session: DBSession) -> ApiResponse[None]:
+async def logout(body: RefreshRequest, user_id: CurrentUserId, session: DBSession) -> ApiResponse[None]:
     service = AuthService(session)
-    service.logout(body.refresh_token)
+    service.logout(body.refresh_token, user_id)
     return ok(None)
 
 @router.post("/refresh")

--- a/app/api/auth.py
+++ b/app/api/auth.py
@@ -15,7 +15,9 @@ async def login(body: LoginRequest, session: DBSession) -> ApiResponse[LoginResp
     return ok(result)
 
 @router.post("/logout")
-async def logout(user_id: CurrentUserId) -> ApiResponse[None]:
+async def logout(body: RefreshRequest, _user_id: CurrentUserId, session: DBSession) -> ApiResponse[None]:
+    service = AuthService(session)
+    service.logout(body.refresh_token)
     return ok(None)
 
 @router.post("/refresh")

--- a/app/core/token_store.py
+++ b/app/core/token_store.py
@@ -1,0 +1,29 @@
+"""인메모리 refresh token 저장소.
+
+서버 재시작 시 초기화되며, 이후 Redis/DB로 교체 가능.
+"""
+
+
+class TokenStore:
+    def __init__(self) -> None:
+        # token -> user_id
+        self._tokens: dict[str, str] = {}
+
+    def save(self, token: str, user_id: str) -> None:
+        self._tokens[token] = user_id
+
+    def verify(self, token: str) -> str | None:
+        """토큰이 유효하면 user_id를 반환한다."""
+        return self._tokens.get(token)
+
+    def revoke(self, token: str) -> None:
+        self._tokens.pop(token, None)
+
+    def revoke_all(self, user_id: str) -> None:
+        """해당 유저의 모든 refresh token을 삭제한다."""
+        self._tokens = {
+            t: uid for t, uid in self._tokens.items() if uid != user_id
+        }
+
+
+token_store = TokenStore()

--- a/app/services/auth.py
+++ b/app/services/auth.py
@@ -5,6 +5,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.core.exceptions import UnauthorizedException
 from app.core.nickname import generate_nickname
 from app.core.security import create_access_token, create_refresh_token, decode_token
+from app.core.token_store import token_store
 from app.repositories.user import UserRepository
 from app.schemas.auth import LoginResponse, TokenResponse, UserResponse
 from app.services.social_auth import verify_social_token
@@ -39,20 +40,28 @@ class AuthService:
                 if user is None:
                     raise UnauthorizedException("로그인 처리 중 오류가 발생했습니다")
 
+        refresh = create_refresh_token(user.id)
+        token_store.save(refresh, user.id)
+
         return LoginResponse(
             user=UserResponse.model_validate(user),
             tokens=TokenResponse(
                 access_token=create_access_token(user.id),
-                refresh_token=create_refresh_token(user.id),
+                refresh_token=refresh,
             ),
         )
 
     async def refresh(self, refresh_token: str) -> TokenResponse:
+        if token_store.verify(refresh_token) is None:
+            raise UnauthorizedException("유효하지 않은 리프레시 토큰입니다")
+
         try:
             payload = decode_token(refresh_token)
         except jwt.ExpiredSignatureError:
+            token_store.revoke(refresh_token)
             raise UnauthorizedException("리프레시 토큰이 만료되었습니다")
         except jwt.InvalidTokenError:
+            token_store.revoke(refresh_token)
             raise UnauthorizedException("유효하지 않은 리프레시 토큰입니다")
 
         if payload.get("type") != "refresh":
@@ -66,10 +75,18 @@ class AuthService:
         if user is None:
             raise UnauthorizedException("존재하지 않는 사용자입니다")
 
+        # 기존 토큰 삭제 + 새 토큰 저장
+        token_store.revoke(refresh_token)
+        new_refresh = create_refresh_token(user.id)
+        token_store.save(new_refresh, user.id)
+
         return TokenResponse(
             access_token=create_access_token(user.id),
-            refresh_token=create_refresh_token(user.id),
+            refresh_token=new_refresh,
         )
+
+    def logout(self, refresh_token: str) -> None:
+        token_store.revoke(refresh_token)
 
     async def get_me(self, user_id: str) -> UserResponse:
         user = await self.user_repo.find_by_id(user_id)
@@ -82,4 +99,5 @@ class AuthService:
         user = await self.user_repo.find_by_id(user_id)
         if user is None:
             raise UnauthorizedException("존재하지 않는 사용자입니다")
+        token_store.revoke_all(user_id)
         await self.user_repo.delete(user_id)

--- a/app/services/auth.py
+++ b/app/services/auth.py
@@ -85,7 +85,10 @@ class AuthService:
             refresh_token=new_refresh,
         )
 
-    def logout(self, refresh_token: str) -> None:
+    def logout(self, refresh_token: str, user_id: str) -> None:
+        owner = token_store.verify(refresh_token)
+        if owner != user_id:
+            raise UnauthorizedException("유효하지 않은 리프레시 토큰입니다")
         token_store.revoke(refresh_token)
 
     async def get_me(self, user_id: str) -> UserResponse:

--- a/docs/API_SPEC.md
+++ b/docs/API_SPEC.md
@@ -94,6 +94,14 @@ Bearer 토큰 방식. `Authorization: Bearer <access_token>` 헤더 필수 (로�
 
 **Headers**: `Authorization: Bearer <access_token>`
 
+**Request**
+
+```json
+{
+  "refreshToken": "eyJhbGciOiJIUzI1NiIs..."
+}
+```
+
 **Response 200**
 
 ```json


### PR DESCRIPTION
## 개요
Refresh token을 인메모리 저장소에 관리하여 로그아웃/탈퇴 시 토큰 무효화를 지원한다.

## 변경 사항
- 인메모리 토큰 저장소 추가 (save, verify, revoke, revoke_all)
- 로그인/갱신/로그아웃/탈퇴 시 토큰 저장소 연동
- 로그아웃 API에 refresh token request body 추가
- API 명세 업데이트

## 관련 이슈
- closes #26


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새 기능**
  * 토큰 해지 및 관리 기능이 추가되었습니다. 로그아웃 시 리프레시 토큰이 명시적으로 취소됩니다.

* **버그 수정**
  * 로그아웃 엔드포인트의 동작이 개선되어 토큰 기반 로그아웃이 올바르게 처리됩니다. 계정 삭제 시 모든 활성 토큰이 해지됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->